### PR TITLE
Relax hard versions in the dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = ["torch>=2.5",
                "tokenizers",
                "safetensors",
                "openai",
-               "accelerate"]
+               "accelerate",
+               "fastapi",]
 
 [project.urls]
 Repository = "https://github.com/LBANN/llama.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,12 @@ description = "LBANN Llama inference library"
 readme = "README.md"
 license = {file = "LICENSE"}
 dependencies = ["torch>=2.5",
-               "uvicorn==0.32.0",
-               "transformers==4.46.2",
-               "tokenizers==0.20.3",
-               "safetensors==0.4.5",
-               "openai==1.54.1",
-               "accelerate==1.1.0"]
+               "uvicorn",
+               "transformers",
+               "tokenizers",
+               "safetensors",
+               "openai",
+               "accelerate"]
 
 [project.urls]
 Repository = "https://github.com/LBANN/llama.git"


### PR DESCRIPTION
1. Removes `==` from dependencies in `pyproject.toml`
2. Adds `fastapi` to dependencies

I just tested a clean install, and it worked with 
```
uvicorn==0.32.1
transformers==4.47.0
tokenizers==0.21.0
safetensors==0.4.5
openai==1.57.3
accelerate==1.2.0
fastapi==0.115.6
```