### PR TITLE
Batch requests

### DIFF
--- a/chat_server.py
+++ b/chat_server.py
@@ -21,6 +21,7 @@ import json
 import queue
 import threading
 import time
+from dataclasses import dataclass
 
 import torch
 import torch.distributed as dist
@@ -46,8 +47,23 @@ Process().cpu_affinity(affinity)
 app = FastAPI()
 
 # Global variables
-inputs = model = tokenizer = gen_queue = None
+model = tokenizer = None
 device = torch.device("cuda:0")
+max_batch_size = None
+streaming_request_queue: queue.Queue = None
+nonstreaming_request_queue: queue.Queue = None
+
+
+@dataclass
+class ChatRequest:
+    """
+    Object that stores a chat request.
+    """
+    inputs: list[int]
+    max_tokens: int
+    settings: dict[str, float]
+    streamer_queue: queue.Queue
+    message_queue: queue.Queue
 
 
 class ChatServerTextStreamer(TextStreamer):
@@ -56,43 +72,53 @@ class ChatServerTextStreamer(TextStreamer):
     """
 
     def __init__(
-        self, tokenizer, queue, message_queue, skip_prompt=True, **decode_kwargs
+        self,
+        tokenizer,
+        queues: list[queue.Queue],
+        message_queues: list[queue.Queue],
+        skip_prompt: bool = True,
+        **decode_kwargs,
     ):
         super().__init__(tokenizer, skip_prompt, **decode_kwargs)
-        self.queue = queue
-        self.message_queue = message_queue
+        self.queues = queues
+        self.message_queues = message_queues
         self._prev_token = None
 
-    def put(self, value):
+    def put(self, value: torch.Tensor):
         # Peek at the message queue to see if there are any outstanding messages
-        if not self.message_queue.empty():
-            self.message_queue.get()
+        if len(self.message_queues) == 1 and not self.message_queues[0].empty():
+            # Cancelling prompts is only supported for batch size of 1
+            self.message_queues[0].get()
             chat_synchronize_ranks(
-                inputs, device, ControlInfo(message=ControlMessageType.CANCEL)
+                device, ControlInfo(message=ControlMessageType.CANCEL)
             )
             raise StopIteration
         else:
-            chat_synchronize_ranks(inputs, device)
+            chat_synchronize_ranks(device)
 
         if self.skip_prompt and self.next_tokens_are_prompt:
             # Skip both the prompt and the content header (in LLaMA 3.1, the
             # sequence separator is 128007 followed by '\n\n' which is 271)
-            if value.shape[-1] == 1:  # Skip until start of answer
-                if self._prev_token is None and value.item() < 128000:
+            if value.ndim == 1:  # Skip until start of answer
+                if self._prev_token is None and torch.all(value < 128000):
                     self.next_tokens_are_prompt = False
-                elif self._prev_token == 128007 and value.item() == 271:
+                elif self._prev_token == 128007 and torch.all(value == 271):
                     self.next_tokens_are_prompt = False
                     return
                 else:
-                    self._prev_token = value.item()
+                    # Since all sequences are "right-justified", the first works
+                    self._prev_token = value[0]
                     return
             else:
                 return
 
         v = self.tokenizer.batch_decode(value, skip_special_tokens=True)
 
-        response = {"choices": [{"delta": {"role": "assistant", "content": str(v[0])}}]}
-        self.queue.put(f"data: {json.dumps(response)}\n\n")
+        for i, q in enumerate(self.queues):
+            response = {
+                "choices": [{"delta": {"role": "assistant", "content": str(v[i])}}]
+            }
+            q.put(f"data: {json.dumps(response)}\n\n")
 
     def on_finalized_text(self, _: str, stream_end: bool = False):
         if stream_end:
@@ -113,20 +139,23 @@ async def completions(request: Request):
     if "temperature" in request_body:
         settings["temperature"] = request_body.get("temperature")
 
-    actual_inputs = tokenizer.apply_chat_template(
+    actual_inputs: torch.Tensor = tokenizer.apply_chat_template(
         messages,
         return_tensors="pt",
-    ).to(device)
-    inputs[0, : actual_inputs.shape[-1]] = actual_inputs
-    input_len = actual_inputs.shape[-1]
+    )
+    inputs = actual_inputs.flatten().tolist()
+    input_len = len(inputs)
 
     streamer_queue = queue.Queue()
     message_queue = queue.Queue()
-    streamer = ChatServerTextStreamer(tokenizer, streamer_queue, message_queue)
-    gen_queue.put((input_len, max_tokens, settings, streamer))
+    chat_request = ChatRequest(
+        inputs, max_tokens, settings, streamer_queue, message_queue
+    )
 
     # Return a streaming response
     if stream:
+        streaming_request_queue.put(chat_request)
+        await asyncio.sleep(0.1)  # Yield execution to allow batch size to accumulate
 
         async def content_stream(request: Request):
             try:
@@ -153,9 +182,13 @@ async def completions(request: Request):
             content=content_stream(request), media_type="text/event-stream"
         )
     else:
+        nonstreaming_request_queue.put(chat_request)
+        await asyncio.sleep(0.1)  # Yield execution to allow batch size to accumulate
+
         strip_str = 'data: {"choices": [{"delta": {"role": "assistant", "content": "'
         outputs = []
         # Collect all outputs
+        output_tokens = 0
         while True:
             res = streamer_queue.get()
             if res is None:
@@ -164,6 +197,7 @@ async def completions(request: Request):
             # res = 'data: {"choices": [{"delta": {"role": "assistant", "content": "?"}}]}'
             # but we want to store just the content
             outputs.append(res.split(strip_str)[1][:-7])
+            output_tokens += 1
 
         msg = {
             "choices": [
@@ -176,9 +210,9 @@ async def completions(request: Request):
                 }
             ],
             "usage": {
-                "completion_tokens": len(outputs),
+                "completion_tokens": output_tokens,
                 "prompt_tokens": input_len,
-                "total_tokens": (input_len + len(outputs)),
+                "total_tokens": (input_len + output_tokens),
             },
         }
         # Return the collected outputs as a single response
@@ -194,7 +228,7 @@ class EventLoopTextStreamer(TextStreamer):
 
     def put(self, value):
         # Synchronize every token
-        info: ControlInfo = chat_synchronize_ranks(inputs, device)
+        info: ControlInfo = chat_synchronize_ranks(device)
         if info is not None:
             if info.message == ControlMessageType.CANCEL:
                 raise StopIteration(info)
@@ -218,33 +252,125 @@ async def models():
     }
 
 
-def master_loop(inputs, device, gen_queue, interval_minutes=5):
+def aggregate_tasks(
+    request_queue: queue.Queue, max_batch_size: int, interval_minutes: int
+):
+    """
+    Aggregate tasks from the request queue and process them in a batch.
+    """
+    requests: list[ChatRequest] = []
+    # Process up to `max_batch_size` requests
+    print("Queue size:", request_queue.qsize())
+    while request_queue.qsize() > 0:
+        requests.append(request_queue.get(timeout=interval_minutes * 60))
+
+        # Check for shutdown signal
+        if requests[-1] is None:
+            return None
+
+        if len(requests) >= max_batch_size:
+            break
+
+    # Aggregate the inputs and settings
+    qlen = len(requests)
+    input_len = max([len(x.inputs) for x in requests])
+    actual_inputs = torch.full(
+        (qlen, input_len), tokenizer.eos_token_id, device=device, dtype=torch.long
+    )
+    for i, request in enumerate(requests):
+        actual_inputs[i, -len(request.inputs) :] = torch.tensor(request.inputs)
+
+    max_tokens = max([x.max_tokens for x in requests])
+    settings = {}
+    for request in requests:
+        settings.update(request.settings)
+
+    message_queues = [x.message_queue for x in requests]
+    streamer_queues = [x.streamer_queue for x in requests]
+    input_lengths = [len(x.inputs) for x in requests]
+
+    return (
+        actual_inputs,
+        max_tokens,
+        settings,
+        message_queues,
+        streamer_queues,
+        input_lengths,
+    )
+
+
+def master_loop(
+    inputs,
+    device,
+    streaming_request_queue,
+    nonstreaming_request_queue,
+    batch_delay,
+    interval_minutes=5,
+):
     cache_manager = KVCacheManager(model)
     while True:
         try:
-            task = gen_queue.get(timeout=interval_minutes * 60)
+            if batch_delay > 0 and max_batch_size > 1:
+                time.sleep(batch_delay / 1000)
+
+            # Aggregate tasks from the request queues
+            if not streaming_request_queue.empty():
+                task = aggregate_tasks(
+                    streaming_request_queue, max_batch_size, interval_minutes
+                )
+            elif not nonstreaming_request_queue.empty():
+                task = aggregate_tasks(
+                    nonstreaming_request_queue, max_batch_size, interval_minutes
+                )
+            else:
+                continue
+
             # Check for shutdown signal
             if task is None:
                 chat_synchronize_ranks(
-                    inputs, device, ControlInfo(message=ControlMessageType.EXIT)
+                    device, ControlInfo(message=ControlMessageType.EXIT)
                 )
                 return
 
-            input_len, max_tokens, settings, streamer = task
+            (
+                inputs,
+                max_tokens,
+                settings,
+                message_queues,
+                streamer_queues,
+                input_lengths,
+            ) = task
+            input_len = inputs.shape[1]
 
             # Synchronize the input tokens and lengths
             control_info = ControlInfo(
-                input_len=input_len,
+                batch_size=inputs.shape[0],
+                input_len=inputs.shape[1],
                 max_new_tokens=max_tokens,
                 temperature=settings.get("temperature", None),
             )
-            chat_synchronize_ranks(inputs, device, control_info)
+            chat_synchronize_ranks(device, control_info)
             kwargs = control_info.to_kwargs()
+            dist.broadcast(inputs, 0)
+
+            # Prepare attention mask based on input lengths
+            attention_mask = torch.ones_like(inputs)
+            for i, length in enumerate(input_lengths):
+                if length < input_len:
+                    attention_mask[i, 0 : input_len - length] = 0
+            dist.broadcast(attention_mask, 0)
+
+            streamer = ChatServerTextStreamer(
+                tokenizer, streamer_queues, message_queues
+            )
+
+            if inputs.shape[0] > 1:
+                print("Batched request. Batch size:", inputs.shape[0])
 
             # Generate text as a streaming response
             outputs = model.generate(
-                input_ids=inputs[:, :input_len],
-                attention_mask=torch.ones((1, input_len), device=device),
+                input_ids=inputs,
+                attention_mask=attention_mask,
                 streamer=streamer,
                 max_new_tokens=max_tokens,
                 pad_token_id=tokenizer.eos_token_id,
@@ -256,31 +382,41 @@ def master_loop(inputs, device, gen_queue, interval_minutes=5):
             cache_manager.update(outputs)
 
             # Send signal to end the stream
-            streamer.queue.put(None)
+            for q in streamer.queues:
+                q.put(None)
         except queue.Empty:
             # Send a keepalive signal
             chat_synchronize_ranks(
-                inputs, device, ControlInfo(message=ControlMessageType.KEEPALIVE)
+                device, ControlInfo(message=ControlMessageType.KEEPALIVE)
             )
         except StopIteration:  # Chat interrupted
             # Clear KV cache on interruption
             cache_manager.clear()
 
             # Send signal to end the stream
-            streamer.queue.put(None)
+            for q in streamer.queues:
+                q.put(None)
 
 
 def worker_loop():
     cache_manager = KVCacheManager(model)
-    info: ControlInfo = chat_synchronize_ranks(inputs, device)
+    info: ControlInfo = chat_synchronize_ranks(device)
     while info.message != ControlMessageType.EXIT:
         if info.message != ControlMessageType.KEEPALIVE:
             kwargs = info.to_kwargs()
 
+            # Synchronize the input tokens and lengths
+            inputs = torch.empty(
+                (info.batch_size, info.input_len), device=device, dtype=torch.long
+            )
+            attention_mask = torch.empty_like(inputs)
+            dist.broadcast(inputs, 0)
+            dist.broadcast(attention_mask, 0)
+
             try:
                 outputs = model.generate(
-                    input_ids=inputs[:, : info.input_len],
-                    attention_mask=torch.ones((1, info.input_len), device=device),
+                    input_ids=inputs,
+                    attention_mask=attention_mask,
                     streamer=EventLoopTextStreamer(tokenizer),
                     max_new_tokens=info.max_new_tokens,
                     pad_token_id=tokenizer.eos_token_id,
@@ -298,7 +434,7 @@ def worker_loop():
                     # Clear KV cache on interruption
                     cache_manager.clear()
 
-        info = chat_synchronize_ranks(inputs, device)
+        info = chat_synchronize_ranks(device)
 
 
 def main():
@@ -335,6 +471,9 @@ def main():
     global inputs
     inputs = torch.full((1, 131072), 128002, dtype=torch.long, device=device)
 
+    global max_batch_size
+    max_batch_size = args.max_batch_size
+
     if args.compile:
         model.model.forward = torch.compile(model.model.forward)
 
@@ -347,11 +486,23 @@ def main():
 
     # Run the uvicorn server
     if dist.get_rank() == 0:
+        # Create request queues for users
+        global streaming_request_queue
+        global nonstreaming_request_queue
+        streaming_request_queue = queue.Queue()
+        nonstreaming_request_queue = queue.Queue()
+
         # Start the keepalive thread
-        global gen_queue
-        gen_queue = queue.Queue()
         gen_thread = threading.Thread(
-            target=master_loop, args=(inputs, device, gen_queue), daemon=True
+            target=master_loop,
+            args=(
+                inputs,
+                device,
+                streaming_request_queue,
+                nonstreaming_request_queue,
+                args.batch_delay,
+            ),
+            daemon=True,
         )
         gen_thread.start()
 
@@ -365,10 +516,12 @@ def main():
         print("Loop is over")
 
         # Send shutdown signal to main thread
-        gen_queue.put(None)
+        streaming_request_queue.put(None)
     else:
         # Other ranks participate in the chat server by waiting
         worker_loop()
+
+    dist.destroy_process_group()
 
 
 # Run the app


### PR DESCRIPTION
Implements two flags that adds batching requests together. Distributes the results to the requesting clients appropriately.

This PR also removes the global `inputs` field that was preallocated, in favor of a dynamically allocated input field based on currently aggregated batch size.